### PR TITLE
Add rpmlint action for linting spec files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/rpmlint.yml
+++ b/.github/workflows/rpmlint.yml
@@ -1,0 +1,30 @@
+name: Lint packages
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.spec'
+      - '.github/workflows/rpmlint.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.spec'
+      - '.github/workflows/rpmlint.yml'
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  rpmlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run rpmlint
+        uses: EyeCantCU/rpmlint-action@v0.1.1
+        with:
+          rpmfiles: .


### PR DESCRIPTION
This will automatically lint spec files when they are updated. Additionally, this adds dependabot to keep dependencies up to date.